### PR TITLE
Fix use with git worktree on Ubuntu 16.04

### DIFF
--- a/git-pre-commit-format
+++ b/git-pre-commit-format
@@ -85,6 +85,12 @@ while true; do
     top_dir=$(cd "$git_test_dir" && git rev-parse --show-toplevel) || \
         error_exit "You need to be in the git repository to run this script."
 
+    # try to handle git work-tree
+    declare git_common_dir
+    if git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+        top_dir=$(realpath "$git_common_dir/..")
+    fi
+
     [ -e "$top_dir/.git" ] || \
         error_exit "No .git directory in $top_dir."
 


### PR DESCRIPTION
Git 2.7.4 in Ubuntu 16.04 does not support git rev-parse
--show-superproject-working-tree, which prevents the hook from
working correctly when committing inside a worktree.