### PR TITLE
Add support for formatting hpp files

### DIFF
--- a/apply-format
+++ b/apply-format
@@ -324,7 +324,7 @@ else # Diff-only.
         | "${format_diff_args[@]}" \
             -p1 \
             -style="$style" \
-            -iregex="$exclusions_regex"'.*\.(c|cpp|cxx|cc|h|m|mm|js|java)' \
+            -iregex="$exclusions_regex"'.*\.(c|cpp|cxx|cc|h|hpp|m|mm|js|java)' \
             > "$patch_dest" \
         || exit 1
 


### PR DESCRIPTION
This PR addresses issue #16. It adds the `hpp` extension to the regex used by `clang-format-diff` so that hpp files are formatted as well as other source files.