### PR TITLE
Renaming 'path' to 'fix'

### DIFF
--- a/apply-format
+++ b/apply-format
@@ -72,17 +72,17 @@ ${b}DESCRIPTION${n}
     ${b}-f, --whole-file${n}
         Reformat the specified files completely (including parts you didn't
         change).
-        The patch is printed on stdout by default. Use -i if you want to modify
+        The fix is printed on stdout by default. Use -i if you want to modify
         the files on disk.
 
     ${b}--staged, --cached${n}
         Reformat only code which is staged for commit.
-        The patch is printed on stdout by default. Use -i if you want to modify
+        The fix is printed on stdout by default. Use -i if you want to modify
         the files on disk.
 
     ${b}-i${n}
         Reformat the code and apply the changes to the files on disk (instead
-        of just printing the patch on stdout).
+        of just printing the fix on stdout).
 
     ${b}--apply-to-staged${n}
         This is like specifying both --staged and -i, but the formatting
@@ -334,9 +334,9 @@ else # Diff-only.
             exit 0
         fi
         patch -p0 < "$patch_dest" || \
-            error_exit "Cannot apply patch to local files."
+            error_exit "Cannot apply fix to local files."
         git apply -p0 --cached < "$patch_dest" || \
-            error_exit "Cannot apply patch to git staged changes."
+            error_exit "Cannot apply fix to git staged changes."
     fi
 
 fi

--- a/git-pre-commit-format
+++ b/git-pre-commit-format
@@ -322,12 +322,12 @@ fi
 
 echo
 echo "${b}The staged content is not formatted correctly.${n}"
-echo "The patch shown above can be applied automatically to fix the formatting."
+echo "The fix shown above can be applied automatically to the commit."
 echo
 
 if $this_is_a_merge; then
     echo "${b}You appear to be committing the result of a merge. It is not${n}"
-    echo "${b}recommended to apply the patch if it will reformat any code you${n}"
+    echo "${b}recommended to apply the fix if it will reformat any code you${n}"
     echo "${b}did not modify in your branch.${n}"
     echo
     readonly recommend_apply=" (not recommended for merge!)"
@@ -342,7 +342,7 @@ else
 fi
 
 echo "You can:"
-echo " ${bold_apply}[a]: Apply the patch${recommend_apply}${n}"
+echo " ${bold_apply}[a]: Apply the fix${recommend_apply}${n}"
 echo " ${bold_force}[f]: Force and commit anyway${recommend_force}${n}"
 echo " [c]: Cancel the commit"
 echo " [?]: Show help"
@@ -359,18 +359,18 @@ while true; do
             patch -p0 < "$patch" || \
                 error_exit \
                 $'\n' \
-                $'Cannot apply patch to local files.\n' \
+                $'Cannot apply fix to local files.\n' \
                 $'Have you modified the file locally after starting the commit?'
             git apply -p0 --cached < "$patch" || \
                 error_exit \
                 $'\n' \
-                $'Cannot apply patch to git staged changes.\n' \
+                $'Cannot apply fix to git staged changes.\n' \
                 $'This may happen if you have some overlapping unstaged changes. To solve\n' \
                 $'you need to stage or reset changes manually.'
 
             if $this_is_a_merge; then
                 echo
-                echo "Applied the patch to reformat the merge commit."
+                echo "Applied the fix to reformat the merge commit."
                 echo "You can always abort by quitting your editor with no commit message."
                 echo
                 echo -n "Press return to continue."


### PR DESCRIPTION
This is a purely cosmetic change to avoid confusion between the 'patch' (aka the future commit) that is handled by the hook and the 'fix' that is proposed by clang-format.

I find it just way less confusing to write a 'fix' when speaking about the patch proposed by clang-format and write a 'patch' when speaking about the future commit. This is just a dumb proposal, so feel free to do what you want with it. :-)

And, thanks for this work! This is really useful!