### PR TITLE
Ignore exit code of clang-format-diff

### DIFF
--- a/apply-format
+++ b/apply-format
@@ -325,8 +325,7 @@ else # Diff-only.
             -p1 \
             -style="$style" \
             -iregex="$exclusions_regex"'.*\.(c|cpp|cxx|cc|h|hpp|m|mm|js|java)' \
-            > "$patch_dest" \
-        || exit 1
+            > "$patch_dest"
 
     if [ "$apply_to_staged" = true ]; then
         if [ ! -s "$patch_dest" ]; then

--- a/tests/mixin_git.py
+++ b/tests/mixin_git.py
@@ -68,7 +68,11 @@ class GitRepository:
         kwargs['stderr'] = subprocess.STDOUT
         kwargs['universal_newlines'] = True
         with self.work_dir():
-            return subprocess.check_output(args, **kwargs)
+            try:
+                return subprocess.check_output(args, **kwargs)
+            except subprocess.CalledProcessError as exc:
+                exc.add_note(exc.output)
+                raise exc
 
     def git_check_call(self, *args):
         return self.check_call('git', *args)

--- a/tests/mixin_scripts_repo.py
+++ b/tests/mixin_scripts_repo.py
@@ -137,7 +137,8 @@ class ScriptsWorkTreeRepoMixin(ScriptsRepoMixin):
         self.repo = GitRepository(worktree_branch_path)
 
         # The new module may have submodules, make sure they are synced.
-        self.repo.git_check_output('submodule', 'update', '--init', '--recursive')
+        self.repo.git_check_output('-c', 'protocol.file.allow=always',
+                                   'submodule', 'update', '--init', '--recursive')
 
         # If case we cloned the current repo but there's unstaged content.
         self.update_scripts()
@@ -169,7 +170,8 @@ class SubmoduleMixin():
 
     def new_repo_with_submodule(self):
         repo = self.new_repo()
-        repo.git_check_output('submodule', 'add', self.this_repo_path(), self.SUBMODULE_DIR)
+        repo.git_check_output('-c', 'protocol.file.allow=always', 'submodule', 'add',
+                              self.this_repo_path(), self.SUBMODULE_DIR)
         repo.commit()
         return repo
 

--- a/tests/test_apply_format.py
+++ b/tests/test_apply_format.py
@@ -159,8 +159,8 @@ class FormatTestCaseBase():
         # Two files need changes.
         self.repo.write_file(data.FILENAME_ALT, data.CODE)
         output = self.apply_format_output()
-        douple_patch = data.PATCH + data.PATCH.replace(data.FILENAME, data.FILENAME_ALT)
-        self.assertEqual(self.simplify_diff(output), douple_patch)
+        double_patch = data.PATCH + data.PATCH.replace(data.FILENAME, data.FILENAME_ALT)
+        self.assertEqual(self.simplify_diff(output), double_patch)
 
         # Stage the second file. Two need changes, one is staged the other isn't.
         self.repo.add(data.FILENAME_ALT)


### PR DESCRIPTION
Adapt to breaking change in clang-format-diff 18.x. The PR also includes a few unrelated cleanups.

Closes: #33