### PR TITLE
[#31] Force `git diff` to use the default prefixes.

### DIFF
--- a/apply-format
+++ b/apply-format
@@ -302,7 +302,11 @@ else # Diff-only.
         readonly patch_dest=/dev/stdout
     fi
 
-    declare git_args=(git diff -U0 --no-color)
+    # To support git when it is configured to use a non-default prefix, use
+    # --src-prefix and --dst-prefix to set the default prefixes explicitly. We
+    # don't use the newer --default-prefix option because we want to support git
+    # versions older than 2.41.
+    declare git_args=(git diff -U0 --no-color --src-prefix=a/ --dst-prefix=b/)
     [ "$staged" = true ] && git_args+=("--staged")
 
     # $format_diff may contain a command ("python") and the script to excute, so we


### PR DESCRIPTION
This supports the `diff.noPrefix` git configuration.

* Fixes #31