### PR TITLE
Fix hang in worktrees of bare repositories

### DIFF
--- a/git-pre-commit-format
+++ b/git-pre-commit-format
@@ -110,6 +110,23 @@ while true; do
         # We are done! top_dir is the root git directory.
         break
     elif [ -f "$top_dir/.git" ]; then
+        # Either a linked worktree or a submodule. In a linked worktree the
+        # git dir (".../worktrees/NAME") differs from the common dir, while
+        # in a submodule they are the same (".../modules/NAME").
+        declare git_dir=
+        if git_dir=$(git -C "$git_test_dir" rev-parse --git-dir 2>/dev/null); then
+            # The git dir could be relative, so we make it absolute.
+            git_dir=$(cd "$git_test_dir" && realpath "$git_dir")
+        fi
+        if [ -n "${git_common_dir:-}" ] && [ "$git_dir" != "$git_common_dir" ]; then
+            # We are in a linked worktree of a bare repository (worktrees of
+            # normal repositories were already handled above). There is no
+            # main checkout, so use the worktree's own top level directory
+            # (undoing the maybe_top_dir guess, which could have matched a
+            # "gitdir: ..." pointer file next to the bare repository).
+            top_dir=$(git -C "$git_test_dir" rev-parse --show-toplevel)
+            break
+        fi
         # We are in a submodule.
         git_test_dir="$git_test_dir/.."
     fi
@@ -117,7 +134,12 @@ done
 
 readonly top_dir
 
-hook_path="$top_dir/.git/hooks/pre-commit"
+# Ask git where the hooks live as, in a linked worktree, they are in the
+# common git directory, not in "$top_dir/.git" (which is a file).
+hook_dir=$(cd "$top_dir" && realpath "$(git rev-parse --git-path hooks)") || exit 1
+readonly hook_dir
+
+hook_path="$hook_dir/pre-commit"
 readonly hook_path
 
 me=$(realpath "$bash_source") || exit 1


### PR DESCRIPTION
The loop finding the top-level git directory assumed that a .git file means we are in a submodule and walked up one directory per iteration. In a linked worktree whose main repository is bare, .git is also a file but there is no main checkout to find, so the loop never terminated and eventually failed with an unusably long path.

Distinguish the two cases by comparing the git dir with the common git dir: they differ in a linked worktree (.../worktrees/NAME vs the main git dir) but are the same in a submodule.

Also derive the hook location from "git rev-parse --git-path hooks" instead of hardcoding $top_dir/.git/hooks, so that "install" works in linked worktrees where the hooks live in the common git directory. --git-path is available since git 2.5, which predates the oldest version this script supports (2.7.4, per the comment about worktree handling).